### PR TITLE
Feature/ci cd to curseforge

### DIFF
--- a/.github/workflows/zip-and-upload-to-curseforge.yml
+++ b/.github/workflows/zip-and-upload-to-curseforge.yml
@@ -1,0 +1,34 @@
+name: Upload to CurseForge
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  Zip-And-Upload-Addon-ZIP:  
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Zip files into addon.zip
+        uses: papeloto/action-zip@v1
+        with:
+          files: Data.lua FlightTimerClassic.lua FlightTimerClassic.toc
+          dest: addon.zip
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: FlightTimerClassic
+          path: ${{ github.workspace }}/addon.zip
+      - name: Echo Create new Version in CurseForge
+        shell: bash
+        run: 'echo curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''alpha'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"'
+      - name: Create new Version in CurseForge
+        shell: bash
+        env:
+          PROJECTID: ${{ secrets.CURSEFORGE__PROJECTID }}
+          TOKEN: ${{ secrets.CURSEFORGE__TOKEN }}
+        run: 'curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''alpha'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"' 

--- a/.github/workflows/zip-and-upload-to-curseforge.yml
+++ b/.github/workflows/zip-and-upload-to-curseforge.yml
@@ -27,6 +27,7 @@ jobs:
         shell: bash
         run: 'echo curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''alpha'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"'
       - name: Create new Version in CurseForge
+        if: github.event_name != 'pull_request'
         shell: bash
         env:
           PROJECTID: ${{ secrets.CURSEFORGE__PROJECTID }}

--- a/.github/workflows/zip-and-upload-to-curseforge.yml
+++ b/.github/workflows/zip-and-upload-to-curseforge.yml
@@ -25,8 +25,8 @@ jobs:
           path: ${{ github.workspace }}/addon.zip
       - name: Echo Create new Version in CurseForge
         shell: bash
-        run: 'echo curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''alpha'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"'
+        run: 'echo curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''beta'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"'
       - name: Create new Version in CurseForge
         if: github.event_name != 'pull_request'
         shell: bash
-        run: 'curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''alpha'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"' 
+        run: 'curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''beta'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"' 

--- a/.github/workflows/zip-and-upload-to-curseforge.yml
+++ b/.github/workflows/zip-and-upload-to-curseforge.yml
@@ -29,7 +29,4 @@ jobs:
       - name: Create new Version in CurseForge
         if: github.event_name != 'pull_request'
         shell: bash
-        env:
-          PROJECTID: ${{ secrets.CURSEFORGE__PROJECTID }}
-          TOKEN: ${{ secrets.CURSEFORGE__TOKEN }}
         run: 'curl -v -H "X-Api-Token: ${{ secrets.CURSEFORGE__TOKEN }}" -F "metadata={ ''changelog'': ''New version from Github'', ''displayName'': ''Flight Timer Classic'', ''gameVersions'': [8722], ''releaseType'': ''alpha'' }" -F file=@${{ github.workspace }}/addon.zip "https://wow.curseforge.com/api/projects/${{ secrets.CURSEFORGE__PROJECTID }}/upload-file"' 


### PR DESCRIPTION
This workflow has 1 job of 5 steps:

1. Checkout the repository
2. Create addon.zip Zip file containing:
    - Data.lua 
    - FlightTimerClassic.lua 
    - FlightTimerClassic.toc 
3. Upload zip file as an artifact, so the generated zip file can be downloaded from the pipeline, for inspection.
4. Echo the curl command that we're going to issue to the curse forge API, with the secrets obfuscated.
5. Run the curl command.

For this to work, you need to create an API token from https://www.curseforge.com/account/api-tokens. Then create 2 repository secrets (from the repository settings menu in github):

1. CURSEFORGE__TOKEN with the generated token
2. CURSEFORGE__PROJECTID this is not really a secret but this way it was easier for me to try the workflow out in a test project. It needs to be the projectid 554379 no quotes.

This will create a file called addon.zip in the project, which I'm not sure is what we're after. I was thinking we could use something like GitVersion https://gitversion.net/docs/learn/how-it-works to tag the current version with git so we could get something like FlightTimerClassic-X.Y.Z.zip instead

